### PR TITLE
Update make_bulk_fastq.pl

### DIFF
--- a/scripts/make_bulk_fastq.pl
+++ b/scripts/make_bulk_fastq.pl
@@ -151,7 +151,7 @@ if (-s $dir."/Log.final.out") {
     print STDOUT "make_bulk_fastq.pl: using the following input files: \n\tBAM = $bam\n";
 
     ## we need to check if the file was mapped as paired-end; for bulk, this changes some stats and fastq extraction samtools command.
-    my $preads = `grep \"properly paired\" host.bam.flagstat | awk '{printf "%d",\$1+\$3}'`; 
+    my $preads = `grep \"paired in sequencing\" host.bam.flagstat | awk '{printf "%d",\$1+\$3}'`; 
     my $paired = ($preads > 0) ? 1 : 0; 
     if ($paired) { 
         my $total_reads  = `grep "primary\$"      host.bam.flagstat | awk '{printf "%d",\$1/2+\$3/2}'`; 


### PR DESCRIPTION
For the first time, I ran BAM files containing only unmapped reads. In this case the “properly paired” field reports 0, which makes sense because that counter is based on the 0x2 flag, since all reads are unmapped (0x4 set). I know the reads are paired as the reads flag contain 0x1, and that shows up correctly under the “paired in sequencing” line in the flagstat output.